### PR TITLE
Remove private dependent objects from console logging

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -118,7 +118,7 @@ var App = function (config, deps) {
   }
 
   deps = deps || {};
-  this.finder = deps.finder || require('./finder')();
+  this._finder = deps.finder || require('./finder')();
 
   return this.configure(config);
 };
@@ -278,8 +278,8 @@ App.prototype.configure = function (config) {
 
   if (appRootSet) {
     appLocated = Q.all([
-      this.finder.checkIsDirectory(config.appRoot),
-      this.finder.checkIsFile(path.join(config.appRoot, config.appLocalPath))
+      this._finder.checkIsDirectory(config.appRoot),
+      this._finder.checkIsFile(path.join(config.appRoot, config.appLocalPath))
     ]);
   }
 

--- a/src/console-logger.js
+++ b/src/console-logger.js
@@ -7,6 +7,25 @@
 
 var _ = require('lodash');
 
+// private function used recursively by logPublicProperties();
+// copy non-private properties of obj to the object copy
+var copyPublic = function (obj, copy) {
+  var privatePrefix = /^_/;
+
+  _.each(obj, function (value, key) {
+    if (!privatePrefix.test(key)) {
+      if (_.isObject(value) && !_.isArray(value)) {
+        copy[key] = copyPublic(value, {});
+      }
+      else {
+        copy[key] = value;
+      }
+    }
+  });
+
+  return copy;
+};
+
 /**
  * Wrapper for console which provides an additional method for replacing
  * the current line of text (for writing progress messages).
@@ -37,6 +56,14 @@ ConsoleLogger.prototype.replace = function (msg) {
   process.stdout.clearLine();  // clear current text
   process.stdout.cursorTo(0);  // move cursor to beginning of line
   process.stdout.write(msg);
+};
+
+/**
+ * Write properties of an object to the console, excluding any
+ * properties which begin with '_' (private ones)
+ */
+ConsoleLogger.prototype.logPublicProperties = function (obj) {
+  console.log(copyPublic(obj, {}));
 };
 
 module.exports = ConsoleLogger;

--- a/src/env.js
+++ b/src/env.js
@@ -395,28 +395,28 @@ var Env = function (config, deps) {
    * @type CommandRunner
    * @instance
    */
-  this.commandRunner = deps.commandRunner || require('./command-runner')(false);
+  this._commandRunner = deps.commandRunner || require('./command-runner')(false);
 
   /**
    * @member
    * @type AppSkeleton
    * @instance
    */
-  this.appSkeleton = deps.appSkeleton || require('./app-skeleton')();
+  this._appSkeleton = deps.appSkeleton || require('./app-skeleton')();
 
   /**
    * @member
    * @type Finder
    * @instance
    */
-  this.finder = deps.finder || require('./finder')();
+  this._finder = deps.finder || require('./finder')();
 
   /**
    * @member
    * @type BuildTools
    * @instance
    */
-  this.buildTools = null;
+  this._buildTools = null;
 
   return this.configure(config);
 };
@@ -485,11 +485,11 @@ Env.CONFIG_DEFAULTS = {
  * @returns {BuildTools} configured for this {@link Env}
  */
 Env.prototype.getBuildTools = function () {
-  if (!this.buildTools) {
-    this.buildTools = BuildTools(this, this.commandRunner);
+  if (!this._buildTools) {
+    this._buildTools = BuildTools(this, this._commandRunner);
   }
 
-  return this.buildTools;
+  return this._buildTools;
 };
 
 /**
@@ -567,7 +567,7 @@ Env.prototype.build = function (app, locations) {
   // file for the app, the manifest, res/, plus assets copied from
   // the appRoot directory; this is pure JS, with no external
   // tools involved
-  this.appSkeleton.generate(appData, locations)
+  this._appSkeleton.generate(appData, locations)
   .then(
     function () {
       // make the apk file; note that we make the R.java file
@@ -647,7 +647,7 @@ Env.prototype.configure = function (config) {
     // find all the directories under "platforms" which match "android-*"
     // and convert into android API level numbers; then select the
     // last (latest) one
-    androidAPILevelPromise = self.finder.globFiles(
+    androidAPILevelPromise = self._finder.globFiles(
       stripTrailingSeparators(config.androidSDKDir) + '/platforms/android-*/'
     )
     .then(
@@ -689,21 +689,21 @@ Env.prototype.configure = function (config) {
 
       // check that the two main directories exist
       return Q.all([
-        self.finder.checkIsDirectory(config.androidSDKDir),
-        self.finder.checkIsDirectory(config.xwalkAndroidDir)
+        self._finder.checkIsDirectory(config.androidSDKDir),
+        self._finder.checkIsDirectory(config.xwalkAndroidDir)
       ]);
     }
   )
   .then(
     function () {
       // locate Android SDK pieces
-      var androidPiecesPromise = locateAndroidPieces(self.finder, config);
+      var androidPiecesPromise = locateAndroidPieces(self._finder, config);
 
       // locate xwalk pieces
-      var xwalkPiecesPromise = locateXwalkPieces(self.finder, config);
+      var xwalkPiecesPromise = locateXwalkPieces(self._finder, config);
 
       // locate executables and files
-      var filesPromise = locateFiles(self.finder, config);
+      var filesPromise = locateFiles(self._finder, config);
 
       return Q.all([androidPiecesPromise, xwalkPiecesPromise, filesPromise]);
     }

--- a/src/xwalk-apkgen.js
+++ b/src/xwalk-apkgen.js
@@ -19,6 +19,7 @@ var Locations = require('./locations');
 var Env = require('./env');
 var App = require('./app');
 var genericUsage = require('./usage');
+var logger = require('./console-logger')();
 
 // show usage message
 var usage = function (cliOpts) {
@@ -27,7 +28,7 @@ var usage = function (cliOpts) {
             'line options, or via JSON config files (see General ' +
             'options below).';
 
-  console.log(genericUsage(msg, cliOpts));
+  logger.log(genericUsage(msg, cliOpts));
 };
 
 /*
@@ -275,11 +276,11 @@ _.each(Env.CONFIG_DEFAULTS, function (value, key) {
 });
 
 // START
-console.log('\n*** STARTING BUILD');
+logger.log('\n*** STARTING BUILD');
 
 var commandRunner = CommandRunner(verbose);
 
-console.log('\n*** CHECKING ENVIRONMENT...');
+logger.log('\n*** CHECKING ENVIRONMENT...');
 
 // App and Env are created asynchronously in parallel
 Q.all([
@@ -294,15 +295,15 @@ Q.all([
     var locations = Locations(app.sanitisedName, app.pkg, env.arch, outDir);
 
     // configuration done
-    console.log('\n*** APPLICATION:');
-    console.log(app);
-    console.log('\n*** ENVIRONMENT:');
-    console.log(env);
-    console.log('\n*** LOCATIONS:');
-    console.log(locations);
+    logger.log('\n*** APPLICATION:');
+    logger.logPublicProperties(app);
+    logger.log('\n*** ENVIRONMENT:');
+    logger.logPublicProperties(env);
+    logger.log('\n*** LOCATIONS:');
+    logger.logPublicProperties(locations);
 
     // make the apk for this environment
-    console.log('\n*** CREATING APPLICATION SKELETON IN ' + outDir);
+    logger.log('\n*** CREATING APPLICATION SKELETON IN ' + outDir);
 
     return env.build(app, locations);
   }
@@ -312,16 +313,16 @@ Q.all([
     var end = new Date();
     var msecs = end.getTime() - start.getTime();
     var secs = (msecs / 1000);
-    console.log('\n*** DONE\n*** BUILD TIME: ' + secs + ' seconds\n' +
+    logger.log('\n*** DONE\n*** BUILD TIME: ' + secs + ' seconds\n' +
                 '*** Final output apk:\n    ' + finalApk);
   },
 
   function (e) {
     console.error('!!!!!!! error occurred');
-    console.log();
+    logger.log();
     console.error(e.stack);
-    console.log();
-    console.log('show options by calling this script with the --help option');
+    logger.log();
+    logger.log('show options by calling this script with the --help option');
     process.exit(1);
   }
 );

--- a/test/unit/env.test.js
+++ b/test/unit/env.test.js
@@ -330,7 +330,7 @@ describe('Env.build()', function () {
     .then(
       function (env) {
         // manually set a stub on the Env object
-        env.buildTools = buildTools;
+        env._buildTools = buildTools;
 
         try {
           env.build(app, locations).should.become(locations.finalApk)


### PR DESCRIPTION
Move private dependencies into "_" properties, then don't output them on the console when running from CLI tools.

ConsoleLogger now has a useful method, logPublicProperties(), which only prints properties to the console if they don't start with "_".

Fixes #9
